### PR TITLE
Removed variables not being used in initUniverse function

### DIFF
--- a/canvaslife.js
+++ b/canvaslife.js
@@ -124,9 +124,6 @@ var life = (function () {
 
 
     function initUniverse(canvasSelector) {
-        var l = life,
-            g = graphics;
-
         graphics.initCanvas(canvasSelector);
         life.xCells = Math.floor((graphics.canvas.width - 1) / graphics.cellSize);
         life.yCells = Math.floor((graphics.canvas.height - 1) / graphics.cellSize);


### PR DESCRIPTION
While working on adding a way for the user to be able to change the cell size without modifying it in the script itself, I stumbled upon these variables not being used.
