### PR TITLE
Simplified array assignment in nextGen

### DIFF
--- a/canvaslife.js
+++ b/canvaslife.js
@@ -179,11 +179,7 @@ var life = (function () {
             g = graphics,
             count;
 
-        for (x = 0; x < life.xCells; x++) {
-            for (y = 0; y < life.yCells; y++) {
-                life.next[x][y] = life.prev[x][y];
-            }
-        }
+        life.next = life.prev;
 
         for (x = 0; x < life.xCells; x++) {
             for (y = 0; y < life.yCells; y++) {
@@ -202,11 +198,7 @@ var life = (function () {
 
         graphics.smartPaint();
 
-        for (x = 0; x < life.xCells; x++) {
-            for (y = 0; y < life.yCells; y++) {
-                life.prev[x][y] = life.next[x][y];
-            }
-        }
+        life.prev = life.next;
     }
 
     function toggleLife() {


### PR DESCRIPTION
I removed the for loops used to set life.prev equal to life.next. This should work the same way.
